### PR TITLE
Make GitHub organization configurable via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # PR Viewer
 
-This React application allows you to view open pull requests from GitHub repositories in the OpenDevin organization.
+This React application allows you to view open pull requests from GitHub repositories in a GitHub organization. By default, it uses the All-Hands-AI organization.
 
 ## Setup
 
 1. Clone the repository
 2. Install dependencies: `npm install`
-3. Create a `.env` file in the root directory and add your GitHub token:
+3. Create a `.env` file in the root directory and add your configuration:
    ```
+   # Required: GitHub token for API access
    VITE_GITHUB_TOKEN=your_github_token_here
+   
+   # Optional: GitHub organization to fetch repositories from (defaults to All-Hands-AI)
+   VITE_GITHUB_ORG=your_github_org_here
    ```
 4. Run the development server: `npm run dev`
 5. Open your browser and navigate to the URL provided by Vite (usually http://localhost:5173)
@@ -23,7 +27,7 @@ To build the app for production, use: `npm run build`
 
 ## Note
 
-Make sure to replace `your_github_token_here` with an actual GitHub personal access token that has the necessary permissions to read repository and pull request information from the OpenDevin organization.
+Make sure to replace `your_github_token_here` with an actual GitHub personal access token that has the necessary permissions to read repository and pull request information from the target organization.
 
 ## License
 

--- a/src/PullRequestViewer.tsx
+++ b/src/PullRequestViewer.tsx
@@ -6,6 +6,7 @@ import { Octokit } from '@octokit/rest';
 import Select from 'react-select';
 
 const octokit = new Octokit({ auth: import.meta.env.VITE_GITHUB_TOKEN });
+const GITHUB_ORG = import.meta.env.VITE_GITHUB_ORG || 'All-Hands-AI';
 
 interface PullRequest {
   title: string;
@@ -29,7 +30,7 @@ const PullRequestViewer: React.FC = () => {
     const fetchRepos = async () => {
       try {
         const response = await octokit.repos.listForOrg({
-          org: 'OpenDevin',
+          org: GITHUB_ORG,
           type: 'all',
         });
         const repoOptions = response.data.map(repo => ({
@@ -54,7 +55,7 @@ const PullRequestViewer: React.FC = () => {
 
           while (hasNextPage) {
             const response = await octokit.pulls.list({
-              owner: 'OpenDevin',
+              owner: GITHUB_ORG,
               repo: selectedRepo.value,
               state: 'open',
               per_page: 100,


### PR DESCRIPTION
- Added VITE_GITHUB_ORG environment variable to configure target GitHub organization
- Set All-Hands-AI as the default organization
- Updated documentation in README.md